### PR TITLE
Ot130 68 crear metodo petición get a los endpoints privados de la api

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -35,7 +35,7 @@ const Patch = async (url, body) => {
 const Get = async (url, id = null) => {
   const response = {};
   try {
-    const { data } = await instance.get(`${url}${id ? '/' + id : ''}`, getAuthorization());
+    const { data } = await instance.get(`${url}${id ? '/' + id : ''}`, getHeaders());
     response.data = data;
   } catch (error) {
     response.error = error;
@@ -72,9 +72,13 @@ const getToken = () => {
 const getAuthorization = () => {
   const token = getToken();
   return {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    Authorization: `Bearer ${token}`,
+  };
+};
+
+const getHeaders = () => {
+  return {
+    headers: getAuthorization(),
   };
 };
 

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -72,7 +72,9 @@ const getToken = () => {
 const getAuthorization = () => {
   const token = getToken();
   return {
-    Authorization: `Bearer ${token}`,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   };
 };
 

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,10 +1,12 @@
-import axios from "axios";
+import axios from 'axios';
 
+const token = localStorage.getItem('token');
 const config = {
-  baseURL: "http://ongapi.alkemy.org/api/",
+  baseURL: 'http://ongapi.alkemy.org/api/',
   headers: {
-    //Group: 130, //Aqui va el ID del equipo!!
-    "content-type": "application/json",
+    Group: 130, //Aqui va el ID del equipo!!
+    Authorization: `${token}`,
+    'content-type': 'application/json',
   },
 };
 
@@ -23,10 +25,10 @@ const Post = async (url, body) => {
 
 const Patch = async (url, data) => await instance.patch(url, data);
 
-const Get = async (url) => {
+const Get = async (url, id = null) => {
   const response = {};
   try {
-    const { data } = await instance.get(url);
+    const { data } = await instance.get(`${url}/${id}`);
     response.data = data;
   } catch (error) {
     response.error = error;
@@ -48,15 +50,15 @@ const Put = async (url, body) => {
 };
 
 const getToken = () => {
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem('token');
   return token || '';
-}
+};
 
 const getAuthorization = () => {
   const token = getToken();
   return {
     Authorization: `Bearer ${token}`,
   };
-}
+};
 
 export { Get, Post, Patch, Put, Delete };

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -29,7 +29,7 @@ const Patch = async (url, data) => await instance.patch(url, data);
 const Get = async (url, id = null) => {
   const response = {};
   try {
-    const { data } = await instance.get(`${url}${id ? '/' + id : ''}`);
+    const { data } = await instance.get(`${url}${id ? '/' + id : ''}`, getAuthorization());
     response.data = data;
   } catch (error) {
     response.error = error;

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -71,14 +71,14 @@ const getToken = () => {
 
 const getAuthorization = () => {
   const token = getToken();
-  return {
-    Authorization: `Bearer ${token}`,
-  };
+  return `Bearer ${token}`;
 };
 
 const getHeaders = () => {
   return {
-    headers: getAuthorization(),
+    headers: {
+      Authorization: getAuthorization(),
+    },
   };
 };
 

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,11 +1,12 @@
 import axios from 'axios';
 
 const token = localStorage.getItem('token');
+
 const config = {
   baseURL: 'http://ongapi.alkemy.org/api/',
   headers: {
-    Group: 130, //Aqui va el ID del equipo!!
-    Authorization: `${token}`,
+    //Group: 130, //Aqui va el ID del equipo!!
+    Authorization: `Beared ${token}`,
     'content-type': 'application/json',
   },
 };
@@ -28,7 +29,7 @@ const Patch = async (url, data) => await instance.patch(url, data);
 const Get = async (url, id = null) => {
   const response = {};
   try {
-    const { data } = await instance.get(`${url}/${id}`);
+    const { data } = await instance.get(`${url}${id ? '/' + id : ''}`);
     response.data = data;
   } catch (error) {
     response.error = error;


### PR DESCRIPTION
Método get a los endpoints privados de la API.
El método es reutilizable: funciona tanto para traer todos los elementos de la ruta, como alguno especifico. 
Atributos del método: Ruta (Obligatoria) y Id (Opcional).
Enviando encabezado Autorización con el token de usuario.