### PR TITLE
OT130-104 Mostrar errores peticiones

### DIFF
--- a/src/Screens/Activities/ActivitiesCreation.js
+++ b/src/Screens/Activities/ActivitiesCreation.js
@@ -1,6 +1,5 @@
 import * as Yup from 'yup';
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
 import { Formik } from 'formik';
 import ActivitiesForm from '../../Components/Activities/ActivitiesForm';
 import { saveActivityData } from '../../Services/activitiesService';
@@ -8,7 +7,7 @@ import { toBase64 } from '../../Helpers/base64';
 import { yupImages, yupLongDesc, yupTitles } from '../../Helpers/formValidations';
 import '../../Components/FormStyles.css';
 import './styles.css';
-import { ACTIVITY_ADDED_ERROR, ACTIVITY_ADDED_SUCCESSFULLY } from '../../Helpers/messagesText';
+import { ACTIVITY_ADDED_ERROR, ACTIVITY_ADDED_SUCCESSFULLY, NETWORK_ERROR } from '../../Helpers/messagesText';
 import { SuccessAlert, ErrorAlert } from '../../Components/Alert';
 
 const initialValues = {
@@ -18,7 +17,6 @@ const initialValues = {
 };
 
 const ActivitiesCreation = () => {
-  const { go } = useHistory();
   const [loading, setLoading] = useState(false);
 
   const validation = Yup.object().shape({
@@ -31,7 +29,7 @@ const ActivitiesCreation = () => {
     setFieldValue('description', editor.getData());
   };
 
-  const handleSubmit = async ({ image, name, description }) => {
+  const handleSubmit = async ({ image, name, description }, resetForm) => {
     setLoading(true);
     const base64Img = await toBase64(image);
     const body = {
@@ -41,20 +39,20 @@ const ActivitiesCreation = () => {
     };
     const { data, error } = await saveActivityData(body);
 
-    setLoading(false);
-    if (data) {
-      SuccessAlert(undefined, ACTIVITY_ADDED_SUCCESSFULLY);
-      go(0);
-    } else {
-      ErrorAlert(ACTIVITY_ADDED_ERROR, error.message);
+    if (error) {
+      ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_ADDED_ERROR)
+    } else if (data.success) {
+      SuccessAlert(ACTIVITY_ADDED_SUCCESSFULLY)
+      resetForm()
     }
+    setLoading(false)
   };
 
   return (
     <Formik
       initialValues={initialValues}
-      onSubmit={(values) => {
-        handleSubmit(values);
+      onSubmit={(values, {resetForm}) => {
+        handleSubmit(values, resetForm);
       }}
       validationSchema={validation}
     >

--- a/src/Screens/Activities/ActivitiesEdition.js
+++ b/src/Screens/Activities/ActivitiesEdition.js
@@ -37,9 +37,11 @@ const ActivitiesEdition = ({ match: { params } }) => {
 
   const loadActivity = async () => {
     const { data, error } = await getActivityDataById(params.id);
-    data
-      ? setActivityData(data.data)
-      : ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_FETCH_ERROR);
+    if (error) {
+      ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_FETCH_ERROR);
+    } else if (data.success) {
+      setActivityData(data.data);
+    }
   };
 
   const handleCKEditorChange = (editor, setFieldValue) => {
@@ -56,21 +58,19 @@ const ActivitiesEdition = ({ match: { params } }) => {
     };
     const { data, error } = await updateActivityDataById(params.id, body);
     setSubmitting(false);
-    
+
     if (error) {
       ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_EDITED_ERROR);
     } else if (data.success) {
-      SuccessAlert(undefined, ACTIVITY_EDITED_SUCCESSFULLY)
-      resetForm() 
+      SuccessAlert(undefined, ACTIVITY_EDITED_SUCCESSFULLY);
+      resetForm();
     }
-    
-   
   };
 
   return activityData ? (
     <Formik
       initialValues={initialValues}
-      onSubmit={(values, {resetForm}) => {
+      onSubmit={(values, { resetForm }) => {
         handleSubmitForm(values, resetForm);
       }}
       validationSchema={validation}

--- a/src/Screens/Activities/ActivitiesEdition.js
+++ b/src/Screens/Activities/ActivitiesEdition.js
@@ -11,6 +11,7 @@ import {
   ACTIVITY_EDITED_ERROR,
   ACTIVITY_EDITED_SUCCESSFULLY,
   ACTIVITY_FETCH_ERROR,
+  NETWORK_ERROR,
   NO_ACTIVITIES,
 } from '../../Helpers/messagesText';
 import { SuccessAlert, ErrorAlert } from '../../Components/Alert';
@@ -36,7 +37,9 @@ const ActivitiesEdition = ({ match: { params } }) => {
 
   const loadActivity = async () => {
     const { data, error } = await getActivityDataById(params.id);
-    data ? setActivityData(data.data) : ErrorAlert(ACTIVITY_FETCH_ERROR, error.message);
+    data
+      ? setActivityData(data.data)
+      : ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_FETCH_ERROR);
   };
 
   const handleCKEditorChange = (editor, setFieldValue) => {
@@ -55,7 +58,7 @@ const ActivitiesEdition = ({ match: { params } }) => {
     setSubmitting(false);
     data
       ? SuccessAlert(undefined, ACTIVITY_EDITED_SUCCESSFULLY)
-      : ErrorAlert(ACTIVITY_EDITED_ERROR, error.message);
+      : ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_EDITED_ERROR);
   };
 
   return activityData ? (

--- a/src/Screens/Activities/ActivitiesEdition.js
+++ b/src/Screens/Activities/ActivitiesEdition.js
@@ -46,7 +46,7 @@ const ActivitiesEdition = ({ match: { params } }) => {
     setFieldValue('description', editor.getData());
   };
 
-  const handleSubmitForm = async ({ image, name, description }) => {
+  const handleSubmitForm = async ({ image, name, description }, resetForm) => {
     setSubmitting(true);
     const base64Img = image && (await toBase64(image)).toString();
     const body = {
@@ -56,16 +56,22 @@ const ActivitiesEdition = ({ match: { params } }) => {
     };
     const { data, error } = await updateActivityDataById(params.id, body);
     setSubmitting(false);
-    data
-      ? SuccessAlert(undefined, ACTIVITY_EDITED_SUCCESSFULLY)
-      : ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_EDITED_ERROR);
+    
+    if (error) {
+      ErrorAlert(error.message === 'Network Error' ? NETWORK_ERROR : ACTIVITY_EDITED_ERROR);
+    } else if (data.success) {
+      SuccessAlert(undefined, ACTIVITY_EDITED_SUCCESSFULLY)
+      resetForm() 
+    }
+    
+   
   };
 
   return activityData ? (
     <Formik
       initialValues={initialValues}
-      onSubmit={(values) => {
-        handleSubmitForm(values);
+      onSubmit={(values, {resetForm}) => {
+        handleSubmitForm(values, resetForm);
       }}
       validationSchema={validation}
     >


### PR DESCRIPTION
**Qué**
- Revisé la manera en que se muestran errores a los usuarios para crear, editar y obtener actividades.
- Agregué caso de error para Network Error

**Para qué**
- Que el usuario tenga un feedback cuando realiza una petición y falla